### PR TITLE
✨ Feat, Refactor : 로그인, 로그아웃, jwt 구현(#9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,5 @@ build/
 ### MySQL ###
 application-mysql.properties
 
-### ElasticSearch ###
-application-elasticsearch.properties
+### JWT ###
+application-security.properties

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    //JWT
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+
     //ElasticSearch
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
     implementation 'jakarta.json:jakarta.json-api:2.0.1'

--- a/src/main/java/com/hanghae/onemanitnews/common/config/ElasticConfig.java
+++ b/src/main/java/com/hanghae/onemanitnews/common/config/ElasticConfig.java
@@ -1,4 +1,4 @@
-package com.hanghae.onemanitnews.common.elasticsearch;
+package com.hanghae.onemanitnews.common.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;

--- a/src/main/java/com/hanghae/onemanitnews/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/hanghae/onemanitnews/common/config/WebSecurityConfig.java
@@ -1,22 +1,45 @@
 package com.hanghae.onemanitnews.common.config;
 
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import com.hanghae.onemanitnews.common.security.CustomAuthenticationEntryPoint;
+import com.hanghae.onemanitnews.common.security.jwt.JwtAccessUtil;
+import com.hanghae.onemanitnews.common.security.jwt.JwtAuthFilter;
+import com.hanghae.onemanitnews.common.security.jwt.JwtRefreshUtil;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 @EnableWebSecurity
 @Configuration
 public class WebSecurityConfig {
+	private final JwtAccessUtil jwtAccessUtil;
+	private final JwtRefreshUtil jwtRefreshUtil;
+	private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
 	@Bean
 	public PasswordEncoder passwordEncoder() {
 		return new BCryptPasswordEncoder(12);
 	} //암호강도 12설정(기본 10, 최소 4, 최대 31)
+
+	@Bean
+	public WebSecurityCustomizer webSecurityCustomizer() {
+		// h2-console 사용 및 resources 접근 허용 설정 => 정적 리소스 필터 제외하여 서버 부하 줄임
+		return (web) -> web.ignoring()
+			//.requestMatchers(PathRequest.toH2Console())
+			.requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+	}
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -29,9 +52,22 @@ public class WebSecurityConfig {
 
 		// .authorizeRequests() : 요청에 대한 권한을 지정
 		http.authorizeRequests()
-			.antMatchers("/api/v1/news/list").permitAll()
-			.antMatchers("/api/v1/member/signup").permitAll()
+			//.antMatchers(HttpMethod.GET, "/api/v1/news/list").permitAll()
+			.antMatchers(HttpMethod.POST, "/api/v1/member/signup").permitAll()
+			.antMatchers(HttpMethod.POST, "/api/v1/member/login").permitAll()
 			.anyRequest().authenticated(); //나머진 토큰 필요
+
+		// JWT Filter 등록 - UPAF필터보다 먼저 적용
+		http.addFilterBefore(new JwtAuthFilter(jwtAccessUtil, jwtRefreshUtil),
+			UsernamePasswordAuthenticationFilter.class);
+		// http.addFilterBefore(new JwtExceptionHandlerFilter(), JwtAuthFilter.class);
+
+		// JWT Filter를 통과한 이후, 어떤 이유로 인해 토큰 만료 됐을 때 검증(ExceptionTranslationFilter)
+		// 401 Error, 인증 실패
+		http.exceptionHandling().authenticationEntryPoint(customAuthenticationEntryPoint);
+
+		// 403 Error, 권한 오류
+		// http.exceptionHandling().accessDeniedHandler(customAccessDeniedHandler);
 
 		return http.build();
 	}

--- a/src/main/java/com/hanghae/onemanitnews/common/exception/CommonExceptionEnum.java
+++ b/src/main/java/com/hanghae/onemanitnews/common/exception/CommonExceptionEnum.java
@@ -10,8 +10,14 @@ public enum CommonExceptionEnum {
 	/* Member 예외 메시지 */
 	DUPLICATE_EMAIL("이미 가입한 Email입니다."),
 	MEMBER_NOT_FOUND("회원이 확인되지 않습니다."),
-	MEMBER_SIGNUP_FAILED("회원가입 실패하였습니다.");
+	MEMBER_SIGNUP_FAILED("회원가입 실패하였습니다."),
+	INCORRECT_PASSWORD("비밀번호가 일치하지 않습니다."),
 
+	/* JWT 예외 메시지 */
+	TOKEN_ENTRY_POINT_ERROR("유효하지 않은 토큰입니다."),
+	TOKEN_DO_FILTER_INTERNAL_ERROR("토큰 검증 과정에서 오류가 있습니다."),
+	EXPIRED_REFRESH_TOKEN("Re-fresh 토큰이 유효하지 않습니다. 다시 로그인해주세요."),
+	NO_REFRESH_TOKEN("Re-fresh 토큰이 확인되지 않습니다.");
 	private final String msg;
 
 	CommonExceptionEnum(String msg) {

--- a/src/main/java/com/hanghae/onemanitnews/common/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/hanghae/onemanitnews/common/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,56 @@
+package com.hanghae.onemanitnews.common.security;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hanghae.onemanitnews.common.exception.CommonExceptionEnum;
+import com.hanghae.onemanitnews.common.response.FailResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint { //토큰 인증 예외처리
+	// 인증과정에서 실패하거나 인증헤더(Authorization)를 보내지 않게되는 경우 401(UnAuthorized) 라는 응답값을 받게되는데요.
+	// 인증되지 않은 사용자의 리소스에 대한 접근 처리는 AuthenticationEntryPoint가 담당
+	// 이를 처리해주는 로직이 바로 AuthenticationEntryPoint라는 인터페이스
+	// Response에 401이 떨어질만한 에러가 발생할 경우 해당로직을 타게되어, commence라는 메소드를 실행
+
+	@Override
+	public void commence(HttpServletRequest request,
+		HttpServletResponse response,
+		AuthenticationException authenticationException) throws IOException {
+
+		FailResponse responseDto = FailResponse.builder()
+			.msg(CommonExceptionEnum.TOKEN_ENTRY_POINT_ERROR.getMsg())
+			.build();
+
+		log.info("CustomAuthenticationEntryPoint 예외발생!");
+
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setStatus(HttpStatus.UNAUTHORIZED.value());
+
+		try (OutputStream os = response.getOutputStream()) {
+			ObjectMapper objectMapper = new ObjectMapper();
+			objectMapper.writeValue(os, responseDto);
+			os.flush();
+		}
+	}
+
+	/*
+	 * 예외 문자열 발송 예제
+	 * response.setContentType("application/json; charset=utf8");
+	 * response.getWriter().println("Oh my god!! 당신 토큰이 좀 이상한거 같다?");
+	 */
+
+}

--- a/src/main/java/com/hanghae/onemanitnews/common/security/MemberDetailsImpl.java
+++ b/src/main/java/com/hanghae/onemanitnews/common/security/MemberDetailsImpl.java
@@ -1,0 +1,79 @@
+package com.hanghae.onemanitnews.common.security;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.hanghae.onemanitnews.common.security.dto.MemberRoleEnum;
+import com.hanghae.onemanitnews.entity.Member;
+
+public class MemberDetailsImpl implements UserDetails {
+	private final Member member; //인증 완료된 Member 객체
+	private final String email; //인증 완료된 Member email
+
+	private final String password; //인증 완료된 Member email
+
+	//생성자
+	public MemberDetailsImpl(Member member, String email, String password) {
+		this.member = member;
+		this.email = email;
+		this.password = password;
+	}
+
+	//게터
+	public Member getMember() {
+		return member;
+	}
+
+	// Member의 권한을 가져오고, Collection에 넣어서 반환함.
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		//MemberRoleEnum role = member.getRole();
+		MemberRoleEnum role = MemberRoleEnum.ONEMAN;  //프로젝트 회원만 회원으로 인정
+		String authority = role.getAuthority();
+
+		SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+		Collection<GrantedAuthority> authorities = new ArrayList<>();
+		authorities.add(simpleGrantedAuthority);
+
+		return authorities;
+	}
+
+	public String getEmail() {
+		return this.email;
+	}
+
+	@Override
+	public String getUsername() {
+		return null;
+	}
+
+	@Override
+	public String getPassword() {
+		return this.password;
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return false;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return false;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return false;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return false;
+	}
+
+}

--- a/src/main/java/com/hanghae/onemanitnews/common/security/MemberDetailsServiceImpl.java
+++ b/src/main/java/com/hanghae/onemanitnews/common/security/MemberDetailsServiceImpl.java
@@ -1,0 +1,31 @@
+package com.hanghae.onemanitnews.common.security;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.hanghae.onemanitnews.common.exception.CommonException;
+import com.hanghae.onemanitnews.common.exception.CommonExceptionEnum;
+import com.hanghae.onemanitnews.entity.Member;
+import com.hanghae.onemanitnews.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberDetailsServiceImpl {
+    /*
+     DB 내 계정정보 유무 검사
+      - 사용자 정보를 DB에서 가져오고, UserDetailsImpl 생성자 매개값으로 전달
+    */
+
+	private final MemberRepository memberRepository;
+
+	public UserDetails loadUserByEmail(String email) throws UsernameNotFoundException {
+		Member member = memberRepository.findByEmail(email).orElseThrow(
+			() -> new CommonException(CommonExceptionEnum.MEMBER_NOT_FOUND)
+		);
+
+		return new MemberDetailsImpl(member, member.getEmail(), member.getPassword());
+	}
+}

--- a/src/main/java/com/hanghae/onemanitnews/common/security/dto/MemberRoleEnum.java
+++ b/src/main/java/com/hanghae/onemanitnews/common/security/dto/MemberRoleEnum.java
@@ -1,0 +1,20 @@
+package com.hanghae.onemanitnews.common.security.dto;
+
+import lombok.Getter;
+
+/* 아직 쓰지 않음 추후에 사용 예정*/
+@Getter
+public enum MemberRoleEnum {
+	ONEMAN(Authority.ONEMAN);  // 프로젝트 이용 가능한 사용자 권한
+
+	//사용자 권한을 String 값으로 사용하기 위함
+	private final String authority;
+
+	MemberRoleEnum(String authority) {
+		this.authority = authority;
+	}
+
+	public static class Authority {
+		public static final String ONEMAN = "ROLE_ONEMAN";
+	}
+}

--- a/src/main/java/com/hanghae/onemanitnews/common/security/jwt/JwtAccessUtil.java
+++ b/src/main/java/com/hanghae/onemanitnews/common/security/jwt/JwtAccessUtil.java
@@ -1,0 +1,120 @@
+package com.hanghae.onemanitnews.common.security.jwt;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.hanghae.onemanitnews.common.security.MemberDetailsServiceImpl;
+import com.hanghae.onemanitnews.common.security.dto.MemberRoleEnum;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component  //개발자가 작성한 class를 Bean으로 등록
+@PropertySource("classpath:application-security.properties")
+@RequiredArgsConstructor
+public class JwtAccessUtil {
+
+	//스프링시큐리티 실습
+	private final MemberDetailsServiceImpl memberDetailsService;
+
+	// 인증 객체 생성
+	public Authentication createAuthentication(String email) {
+		UserDetails userDetails = memberDetailsService.loadUserByEmail(email);
+		return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+	}
+
+	//1. 토큰에 필요한 값
+	public static final String ACCESS_HEADER = "Authorization";  // Header KEY 값(위에 스샷 참고.. 헤더 키값)
+	public static final String AUTHORIZATION_KEY = "accessAuth";  // 사용자 권한 값의 KEY 값 – token안에 사용자 권한 식별용
+	private static final String ONEMAN_PREFIX = "Oneman ";  // Token 식별자 – 토큰 앞에 붙임
+	private static final long TOKEN_TIME = 10 * 60 * 1000L;  // 토큰 만료시간(10분)
+
+	@Value("${jwt.secret.key.access}") //시크릿키 값 가져옴, auth.properties 참고
+	private String secretKeyAccess;
+	private Key accessKey;  //토큰을 만들 때 넣어줄 킷값, 아래 init() 참고
+	private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+	@PostConstruct
+	public void init() {  // 키 객체 값 만드는 부분
+		byte[] bytes = Base64.getDecoder().decode(secretKeyAccess);
+		accessKey = Keys.hmacShaKeyFor(bytes);
+	}
+	// @PostConstruct 처음 객체 생성 시 초기화하는 어노테이션,
+	// 의존성 주입이 이루어진 후 초기화 수행, 근데 아래보니까 HMAC 쓰는데, 암호화할 키 값 만들 때 쓰는 듯,
+	// HMAC(키 XOR 메시지 => 해시함수 => 키 XOR => 해시함수)
+
+	//2. header 토큰을 가져오기
+	public String resolveAccessToken(HttpServletRequest request) { //HttpServletRequest 객체 안에 토큰이 헤더값으로 들어있음
+		String bearerToken = request.getHeader(ACCESS_HEADER); //토큰값 가져오기
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(ONEMAN_PREFIX)) { //앞에 토큰 식별자 있는지 체크 Oenman
+			return bearerToken.substring(7); //디코딩한 후에는 필요없으니 Bearer 문자열은 제외
+		}
+		return null;
+	}
+
+	//3. 토큰 생성
+	public String createAccessToken(String email, MemberRoleEnum role) {
+		Date date = new Date();
+
+		//아래 부분들에 각각 값 세팅하는 부분
+		return ONEMAN_PREFIX +  //Oneman 문자열 들어가는 부분
+			Jwts.builder()  //jwt 만들기ㄱㄱ
+				.setSubject(email)  //유저명 넣고
+				.claim(AUTHORIZATION_KEY, role)  //claim에는 사용자권한 값 넣고
+				.setExpiration(new Date(date.getTime() + TOKEN_TIME)) //여긴 토큰 유효기간 넣고, 1시간
+				.setIssuedAt(date)  //토큰이 언제 생성되었는지
+				.signWith(accessKey, signatureAlgorithm)  //사용할 암호알고리즘 세팅
+				.compact();   //압축하고 암호화 ㄱㄱ
+	}
+
+	//4. 토큰 검증
+	public String validateAccessToken(String accessToken) {
+		try {
+			//토큰값과 암호화 킷값 사용
+			Jwts.parserBuilder().setSigningKey(accessKey).build().parseClaimsJws(accessToken);
+			return "Access";
+		} catch (SecurityException | MalformedJwtException e) {
+			//유효하지 않은 토큰 예외 발생
+			log.info("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+		} catch (ExpiredJwtException e) {
+			//유효하지 않은 토큰 예외 발생
+			log.info("Expired JWT token, 만료된 JWT token 입니다.");
+			return "Refresh";
+		} catch (UnsupportedJwtException e) {
+			//유효하지 않은 토큰 예외 발생
+			log.info("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+		} catch (SignatureException e) {
+			log.info("SignatureException, 서명 예외 발생");
+		} catch (IllegalArgumentException e) {
+			//유효하지 않은 토큰 예외 발생
+			log.info("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+		}
+		return "NO";
+	}
+
+	//5. 토큰에서 사용자 정보 가져오기, getBody()를 통해 사용자 정보 가져옴
+	public Claims getMemberInfoFromAccessToken(String accessToken) {
+		return Jwts.parserBuilder().setSigningKey(accessKey).build().parseClaimsJws(accessToken).getBody();
+	}
+}

--- a/src/main/java/com/hanghae/onemanitnews/common/security/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/hanghae/onemanitnews/common/security/jwt/JwtAuthFilter.java
@@ -1,0 +1,100 @@
+package com.hanghae.onemanitnews.common.security.jwt;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hanghae.onemanitnews.common.exception.CommonExceptionEnum;
+import com.hanghae.onemanitnews.common.response.FailResponse;
+import com.hanghae.onemanitnews.common.security.dto.MemberRoleEnum;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+	private final JwtAccessUtil jwtAccessUtil;
+	private final JwtRefreshUtil jwtRefreshUtil;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		//1. header에서 AccessToken 가져오기
+		String accessToken = jwtAccessUtil.resolveAccessToken(request);  // 2. header에서 AccessToken 가져옴
+
+		//2. Access 토큰 검증
+		if (accessToken != null) { //회원가입, 로그인 시에는 토큰이 없기에 조건문 달아야함
+			String accessTokenCheck = jwtAccessUtil.validateAccessToken(accessToken);
+
+			if (accessTokenCheck.equals("Access")) {
+				Claims info = jwtAccessUtil.getMemberInfoFromAccessToken(
+					accessToken); //5. 토큰에서 사용자 정보 가져오기, getBody()를 통해 사용자 정보 가져옴
+				setAccessAuthentication(info.getSubject()); //getSubject()로 ID값 가져와서 검증.. 아래 45번줄 setAuthentication()
+			}
+
+			if (accessTokenCheck.equals("Refresh")) {
+				String refreshToken = jwtRefreshUtil.resolveRefreshToken(request);
+				if (refreshToken == null) {
+					sendFailureMessage(CommonExceptionEnum.NO_REFRESH_TOKEN, response);
+					return;
+				}
+
+				if (!jwtRefreshUtil.validateRefreshToken(refreshToken)) {
+					sendFailureMessage(CommonExceptionEnum.EXPIRED_REFRESH_TOKEN, response);
+					return;
+				}
+
+				Claims info = jwtRefreshUtil.getMemberInfoFromRefreshToken(refreshToken);
+
+				accessToken = jwtAccessUtil.createAccessToken(info.getSubject(), MemberRoleEnum.ONEMAN);
+				response.addHeader(jwtAccessUtil.ACCESS_HEADER, accessToken);
+
+				setAccessAuthentication(info.getSubject());
+			}
+
+			if (accessTokenCheck.equals("NO")) { //JwtUtil 안에 4. 토큰 검증
+				sendFailureMessage(CommonExceptionEnum.TOKEN_DO_FILTER_INTERNAL_ERROR, response);
+				return; //이거 없으면 콘솔창에 에러 터진거 막 출력됨
+			}
+		}
+		filterChain.doFilter(request, response);
+	}
+
+	// 인증객체 생성하고 SercurityContextHolder 안에 등록
+	public void setAccessAuthentication(String email) {
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+		Authentication authentication = jwtAccessUtil.createAuthentication(email); //JwtUtil 안에 만든 - 인증 객체 생성
+		context.setAuthentication(authentication);
+
+		SecurityContextHolder.setContext(context);
+	}
+
+	public void sendFailureMessage(CommonExceptionEnum exceptionEnum, HttpServletResponse response) throws IOException {
+		//유효하지 않은 토큰 예외 발생
+		FailResponse responseDto = new FailResponse(exceptionEnum.getMsg());
+
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setStatus(HttpStatus.UNAUTHORIZED.value());
+
+		try (OutputStream os = response.getOutputStream()) {
+			ObjectMapper objectMapper = new ObjectMapper();
+			objectMapper.writeValue(os, responseDto);
+			os.flush();
+		}
+	}
+}

--- a/src/main/java/com/hanghae/onemanitnews/common/security/jwt/JwtRefreshUtil.java
+++ b/src/main/java/com/hanghae/onemanitnews/common/security/jwt/JwtRefreshUtil.java
@@ -1,0 +1,109 @@
+package com.hanghae.onemanitnews.common.security.jwt;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.hanghae.onemanitnews.common.security.MemberDetailsServiceImpl;
+import com.hanghae.onemanitnews.common.security.dto.MemberRoleEnum;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@PropertySource("classpath:application-security.properties")
+@RequiredArgsConstructor
+public class JwtRefreshUtil {
+
+	//스프링시큐리티 실습
+	private final MemberDetailsServiceImpl memberDetailsService;
+
+	//1. 토큰에 필요한 값
+	public static final String REFRESH_HEADER = "OneManToken";  // Header KEY 값(위에 스샷 참고.. 헤더 키값)
+	public static final String AUTHORIZATION_KEY = "refreshAuth";  // 사용자 권한 값의 KEY 값 – token안에 사용자 권한 식별용
+	private static final String ONEMAN_PREFIX = "Oneman ";  // Token 식별자 – 토큰 앞에 붙임
+	private static final long REFRESH_TOKEN_TIME = 30 * 60 * 1000L;  // 토큰 만료시간(30분)
+
+	@Value("${jwt.secret.key.refresh}") //시크릿키 값 가져옴, auth.properties 참고
+	private String secretKeyRefresh;
+	private Key refreshKey;  //토큰을 만들 때 넣어줄 킷값, 아래 init() 참고
+	private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS512;
+
+	@PostConstruct
+	public void init() {  // 키 객체 값 만드는 부분
+		byte[] refreshBytes = Base64.getDecoder().decode(secretKeyRefresh);
+		refreshKey = Keys.hmacShaKeyFor(refreshBytes);
+	}
+
+	//2. header 토큰을 가져오기
+	public String resolveRefreshToken(HttpServletRequest request) { //HttpServletRequest 객체 안에 토큰이 헤더값으로 들어있음
+		String bearerToken = request.getHeader(REFRESH_HEADER); //토큰값 가져오기
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(ONEMAN_PREFIX)) { //앞에 토큰 식별자 있는지 체크 Oenman
+			return bearerToken.substring(7); //디코딩한 후에는 필요없으니 Bearer 문자열은 제외
+		}
+
+		return null;
+	}
+
+	//3. 토큰 생성
+	public String createRefreshToken(String email, MemberRoleEnum role) {
+		Date date = new Date();
+
+		//아래 부분들에 각각 값 세팅하는 부분
+		return ONEMAN_PREFIX +  //Oneman 문자열 들어가는 부분
+			Jwts.builder()  //jwt 만들기ㄱㄱ
+				.setSubject(email)  //유저명 넣고
+				.claim(AUTHORIZATION_KEY, role)  //claim에는 사용자권한 값 넣고
+				.setExpiration(new Date(date.getTime() + REFRESH_TOKEN_TIME)) //여긴 토큰 유효기간 넣고, 1시간
+				.setIssuedAt(date)  //토큰이 언제 생성되었는지
+				.signWith(refreshKey, signatureAlgorithm)  //사용할 암호알고리즘 세팅
+				.compact();   //압축하고 암호화 ㄱㄱ
+	}
+
+	//4. 토큰 검증
+	public boolean validateRefreshToken(String refreshTokne) {
+		try {
+			//토큰값과 암호화 킷값 사용
+			Jwts.parserBuilder().setSigningKey(refreshKey).build().parseClaimsJws(refreshTokne);
+			return true;
+		} catch (SecurityException | MalformedJwtException e) {
+			//유효하지 않은 토큰 예외 발생
+			log.info("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+		} catch (ExpiredJwtException e) {
+			//유효하지 않은 토큰 예외 발생
+			e.getMessage();
+			log.info("Expired JWT token, 만료된 JWT token 입니다. 다시 로그인이 필요합니다.");
+		} catch (UnsupportedJwtException e) {
+			//유효하지 않은 토큰 예외 발생
+			log.info("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+		} catch (SignatureException e) {
+			log.info("SignatureException, 서명 예외 발생");
+		} catch (IllegalArgumentException e) {
+			//유효하지 않은 토큰 예외 발생
+			log.info("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+		}
+		return false;
+	}
+
+	//5. 토큰에서 사용자 정보 가져오기, getBody()를 통해 사용자 정보 가져옴
+	public Claims getMemberInfoFromRefreshToken(String refreshToken) {
+		return Jwts.parserBuilder().setSigningKey(refreshKey).build().parseClaimsJws(refreshToken).getBody();
+	}
+}

--- a/src/main/java/com/hanghae/onemanitnews/controller/MemberApiController.java
+++ b/src/main/java/com/hanghae/onemanitnews/controller/MemberApiController.java
@@ -1,5 +1,6 @@
 package com.hanghae.onemanitnews.controller;
 
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.hanghae.onemanitnews.common.response.SuccessResponse;
+import com.hanghae.onemanitnews.controller.request.LoginMemberRequest;
 import com.hanghae.onemanitnews.controller.request.SaveMemberRequest;
 import com.hanghae.onemanitnews.service.MemberService;
 
@@ -29,6 +31,27 @@ public class MemberApiController {
 
 		return new ResponseEntity<>(SuccessResponse.builder()
 			.msg("회원가입 성공")
+			.build(),
+			HttpStatus.OK);
+	}
+
+	@PostMapping("/login")
+	public ResponseEntity<?> login(@RequestBody @Valid LoginMemberRequest loginMemberRequest,
+		HttpServletResponse response) {
+		System.out.println("=========옴??");
+		memberService.login(loginMemberRequest, response);
+
+		return new ResponseEntity<>(SuccessResponse.builder()
+			.msg("로그인이 완료되었습니다.")
+			.build(),
+			HttpStatus.OK);
+	}
+
+	@PostMapping("/logout")
+	public ResponseEntity<?> login() {
+
+		return new ResponseEntity<>(SuccessResponse.builder()
+			.msg("로그아웃 성공하였습니다.")
 			.build(),
 			HttpStatus.OK);
 	}

--- a/src/main/java/com/hanghae/onemanitnews/controller/request/LoginMemberRequest.java
+++ b/src/main/java/com/hanghae/onemanitnews/controller/request/LoginMemberRequest.java
@@ -1,0 +1,19 @@
+package com.hanghae.onemanitnews.controller.request;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+import lombok.Getter;
+
+@Getter
+public class LoginMemberRequest {
+
+	@NotBlank(message = "공백 또는 빈값을 허용하지 않습니다.")
+	@Email(message = "이메일(@) 형식이 아닙니다.")
+	private String email;
+
+	@NotBlank(message = "공백 또는 빈값을 허용하지 않습니다.")
+	@Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8 ~ 16자이내, 영대소문자/숫자/특수문자 3종류 조합")
+	private String password;
+}

--- a/src/main/java/com/hanghae/onemanitnews/entity/Member.java
+++ b/src/main/java/com/hanghae/onemanitnews/entity/Member.java
@@ -11,9 +11,12 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
 public class Member extends Timestamped {

--- a/src/main/java/com/hanghae/onemanitnews/repository/MemberRepository.java
+++ b/src/main/java/com/hanghae/onemanitnews/repository/MemberRepository.java
@@ -1,5 +1,7 @@
 package com.hanghae.onemanitnews.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.hanghae.onemanitnews.entity.Member;
@@ -7,4 +9,6 @@ import com.hanghae.onemanitnews.entity.Member;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	Boolean existsByEmail(String email);
+
+	Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/hanghae/onemanitnews/service/MemberService.java
+++ b/src/main/java/com/hanghae/onemanitnews/service/MemberService.java
@@ -1,11 +1,17 @@
 package com.hanghae.onemanitnews.service;
 
+import javax.servlet.http.HttpServletResponse;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.hanghae.onemanitnews.common.exception.CommonException;
 import com.hanghae.onemanitnews.common.exception.CommonExceptionEnum;
+import com.hanghae.onemanitnews.common.security.dto.MemberRoleEnum;
+import com.hanghae.onemanitnews.common.security.jwt.JwtAccessUtil;
+import com.hanghae.onemanitnews.common.security.jwt.JwtRefreshUtil;
+import com.hanghae.onemanitnews.controller.request.LoginMemberRequest;
 import com.hanghae.onemanitnews.controller.request.SaveMemberRequest;
 import com.hanghae.onemanitnews.entity.Member;
 import com.hanghae.onemanitnews.mapper.MemberMapper;
@@ -19,8 +25,9 @@ public class MemberService {
 
 	private final MemberRepository memberRepository;
 	private final MemberMapper memberMapper;
-
 	private final PasswordEncoder passwordEncoder;
+	private final JwtAccessUtil jwtAccessUtil;
+	private final JwtRefreshUtil jwtRefreshUtil;
 
 	@Transactional
 	public void signup(SaveMemberRequest saveMemberRequest) {
@@ -43,5 +50,30 @@ public class MemberService {
 		} catch (Exception e) {
 			throw new CommonException(CommonExceptionEnum.MEMBER_SIGNUP_FAILED);
 		}
+	}
+
+	@Transactional(readOnly = true)
+	public void login(LoginMemberRequest loginMemberRequest, HttpServletResponse response) {
+		/* 1. 로그인 관련 필드 준비 */
+		String email = loginMemberRequest.getEmail();
+		String password = loginMemberRequest.getPassword();
+
+		//1. 회원 존재 여부 확인
+		Member member = memberRepository.findByEmail(email).orElseThrow(
+			() -> new CommonException(CommonExceptionEnum.MEMBER_NOT_FOUND)
+		);
+
+		//2. 비밀번호 일치여부 확인
+		if (!passwordEncoder.matches(password, member.getPassword())) {
+			throw new CommonException(CommonExceptionEnum.INCORRECT_PASSWORD);
+		}
+
+		//3. Access JWT생성 및 발급
+		response.addHeader(jwtAccessUtil.ACCESS_HEADER,
+			jwtAccessUtil.createAccessToken(email, MemberRoleEnum.ONEMAN)); //AccessToken
+
+		//4. Refresh JWT생성 및 발급
+		response.addHeader(jwtRefreshUtil.REFRESH_HEADER,
+			jwtRefreshUtil.createRefreshToken(email, MemberRoleEnum.ONEMAN)); //RefreshToken
 	}
 }


### PR DESCRIPTION
## PR 타입
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Performance Improvement
- [ ] Bugfix
- [ ] Test Code
- [ ] Code style update (formatting, local variables)
- [ ] Other... Please describe:

## 개요 
- 프로젝트 관련 로그인, 로그아웃, jwt 기능 구현

## 작업 및 변경 사항 
- email/password로 로그인 가능
- jwt로 access/refresh토큰 구현(리팩토링 필요)
- (refactor)엘라스틱서치 config 파일 위치 이동

### 테스트 결과 
![image](https://user-images.githubusercontent.com/31820402/214759150-f04d3722-9b1b-4d0a-8a4a-9bbb55c94446.png)

### 공유 하고 싶은 내용 및 참고 자료
- jwt구현에서 access, refresh util에서 겹치는게 많음 => 리팩토링 필요
- 테스트코드 작성 필요

close #9