### PR TITLE
🔨️ Refactor : node.js 싱글스레드 활용 auto_increment 동시성 제어(순서보장)(#22)

### DIFF
--- a/src/main/java/com/hanghae/onemanitnews/common/exception/CommonExceptionEnum.java
+++ b/src/main/java/com/hanghae/onemanitnews/common/exception/CommonExceptionEnum.java
@@ -13,6 +13,8 @@ public enum CommonExceptionEnum {
 	MEMBER_SIGNUP_FAILED("회원가입 실패하였습니다."),
 	INCORRECT_PASSWORD("비밀번호가 일치하지 않습니다."),
 
+	NODE_JS_COUNT_FAIL("Node.js 서버 Error!!"),
+
 	/* JWT 예외 메시지 */
 	TOKEN_ENTRY_POINT_ERROR("유효하지 않은 토큰입니다."),
 	TOKEN_DO_FILTER_INTERNAL_ERROR("토큰 검증 과정에서 오류가 있습니다."),

--- a/src/main/java/com/hanghae/onemanitnews/controller/MemberApiController.java
+++ b/src/main/java/com/hanghae/onemanitnews/controller/MemberApiController.java
@@ -13,6 +13,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.hanghae.onemanitnews.common.exception.CommonException;
+import com.hanghae.onemanitnews.common.exception.CommonExceptionEnum;
 import com.hanghae.onemanitnews.common.response.SuccessResponse;
 import com.hanghae.onemanitnews.controller.request.LoginMemberRequest;
 import com.hanghae.onemanitnews.controller.request.SaveMemberRequest;
@@ -30,7 +33,11 @@ public class MemberApiController {
 	@PostMapping("/signup")
 	public ResponseEntity<?> signup(@RequestBody @Valid SaveMemberRequest saveMemberRequest) {
 
-		memberService.signup(saveMemberRequest);
+		try {
+			memberService.signup(saveMemberRequest);
+		} catch (JsonProcessingException e) {
+			throw new CommonException(CommonExceptionEnum.MEMBER_SIGNUP_FAILED);
+		}
 
 		return new ResponseEntity<>(SuccessResponse.builder()
 			.msg("회원가입 성공하였습니다.")

--- a/src/main/java/com/hanghae/onemanitnews/service/MemberService.java
+++ b/src/main/java/com/hanghae/onemanitnews/service/MemberService.java
@@ -55,7 +55,7 @@ public class MemberService {
 	@Transactional
 	@Lock(LockModeType.PESSIMISTIC_READ)
 	public void signup(SaveMemberRequest saveMemberRequest) throws JsonProcessingException {
-		//1. 중복 가입 유무 체
+		//1. 중복 가입 유무 체크
 		Boolean isEmail = memberRepository.existsByEmail(saveMemberRequest.getEmail());
 
 		if (isEmail == true) {

--- a/src/main/java/com/hanghae/onemanitnews/service/MemberService.java
+++ b/src/main/java/com/hanghae/onemanitnews/service/MemberService.java
@@ -1,17 +1,29 @@
 package com.hanghae.onemanitnews.service;
 
+import static com.hanghae.onemanitnews.common.exception.CommonExceptionEnum.*;
+
 import java.util.concurrent.TimeUnit;
 
+import javax.persistence.LockModeType;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hanghae.onemanitnews.common.exception.CommonException;
 import com.hanghae.onemanitnews.common.exception.CommonExceptionEnum;
 import com.hanghae.onemanitnews.common.jwt.JwtAccessUtil;
@@ -41,8 +53,9 @@ public class MemberService {
 	private final RedisTokenUtil redisTokenUtil;
 
 	@Transactional
-	public void signup(SaveMemberRequest saveMemberRequest) {
-		//1. 중복 가입 유무 체크
+	@Lock(LockModeType.PESSIMISTIC_READ)
+	public void signup(SaveMemberRequest saveMemberRequest) throws JsonProcessingException {
+		//1. 중복 가입 유무 체
 		Boolean isEmail = memberRepository.existsByEmail(saveMemberRequest.getEmail());
 
 		if (isEmail == true) {
@@ -52,15 +65,35 @@ public class MemberService {
 		//2. 비밀번호 암호화
 		String encryptPassword = passwordEncoder.encode(saveMemberRequest.getPassword());
 
-		//3. Dto -> Entity
+		//3. member_id 최대값 조회(Node.js)
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+		HttpEntity<String> requestEntity = new HttpEntity<>(headers);
+
+		RestTemplate rt = new RestTemplate();
+
+		ResponseEntity<String> response = rt.exchange(
+			"http://172.30.1.1:3000/api/v1/member/count",
+			HttpMethod.POST,
+			requestEntity,
+			String.class
+		);
+
+		String responseBody = response.getBody();
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+		if (jsonNode.get("result").asText().equals("fail")) {
+			throw new CommonException(NODE_JS_COUNT_FAIL);
+		}
+
+		//4. Dto -> Entity
 		Member member = memberMapper.toEntity(saveMemberRequest.getEmail(), encryptPassword);
 
-		//4. 회원가입
-		try {
-			memberRepository.save(member);
-		} catch (Exception e) {
-			throw new CommonException(CommonExceptionEnum.MEMBER_SIGNUP_FAILED);
-		}
+		//5. 회원가입
+		memberRepository.save(member);
 	}
 
 	@Transactional(readOnly = true)


### PR DESCRIPTION
## PR 타입
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Performance Improvement
- [ ] Bugfix
- [ ] Test Code
- [ ] Code style update (formatting, local variables)
- [ ] Other... Please describe:

## 개요 
- 회원가입 시 member_id 순서보장과 동시성 제어를 위해 Multi Thread를 node.js Single Thread로 해결

## 작업 및 변경 사항 
- 회원가입 시 node.js 서버로 요청을 보내 Single Thread로 처리되게끔 로직 추가

### 테스트 결과 
- 순서보장 완료
![image](https://user-images.githubusercontent.com/31820402/220837923-29336580-ddb1-4a79-ba6d-370c425cb1d4.png)

- Jmeter 결과
![image](https://user-images.githubusercontent.com/31820402/220837884-96c9107c-a378-453f-bb2f-89db2e9999eb.png)

![image](https://user-images.githubusercontent.com/31820402/220837851-2dbdd495-d117-4996-a0ad-25afa31e42b9.png)


### 공유 하고 싶은 내용 및 참고 자료
- 기존 로그아웃 리팩터링(#19) 이슈에서 처리진행하여 이슈번호 및 branch가 혼잡하게 된 점 참고

close #22